### PR TITLE
Replace ores in ore veins with correct variants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ dependencies {
 }
 
 loom {
+    accessWidenerPath = file("src/main/resources/universal_ores.accesswidener")
+
     splitEnvironmentSourceSets()
 
     mods {

--- a/src/main/java/fr/hugman/universal_ores/mixin/VeinTypeMixin.java
+++ b/src/main/java/fr/hugman/universal_ores/mixin/VeinTypeMixin.java
@@ -1,0 +1,23 @@
+package fr.hugman.universal_ores.mixin;
+
+import fr.hugman.universal_ores.block.UniversalOresBlocks;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.world.gen.OreVeinSampler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(OreVeinSampler.VeinType.class)
+public class VeinTypeMixin {
+    @ModifyVariable(method = "<init>", at = @At("HEAD"), ordinal = 0, argsOnly = true)
+    private static BlockState modifyOre(BlockState ore) {
+        if (ore.isOf(Blocks.COPPER_ORE)) {
+            return UniversalOresBlocks.GRANITE_ORES.copper().getDefaultState();
+        }
+        if (ore.isOf(Blocks.DEEPSLATE_IRON_ORE)) {
+            return UniversalOresBlocks.TUFF_ORES.iron().getDefaultState();
+        }
+        return ore;
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,7 @@
   "mixins": [
     "universal_ores.mixins.json"
   ],
+  "accessWidener": "universal_ores.accesswidener",
   "depends": {
     "minecraft": "^1.21.1",
     "fabric": "*"

--- a/src/main/resources/universal_ores.accesswidener
+++ b/src/main/resources/universal_ores.accesswidener
@@ -1,0 +1,2 @@
+accessWidener	v1	named
+accessible class net/minecraft/world/gen/OreVeinSampler$VeinType

--- a/src/main/resources/universal_ores.mixins.json
+++ b/src/main/resources/universal_ores.mixins.json
@@ -3,7 +3,8 @@
   "package": "fr.hugman.universal_ores.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "OreFeatureMixin"
+    "OreFeatureMixin",
+    "VeinTypeMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This PR replaces ores in iron and copper veins:
- Deepslate Iron Ore is replaced with Tuff Iron Ore
- Copper Ore is replaced with Granite Copper Ore

![2025-01-23_18 37 09](https://github.com/user-attachments/assets/9ad90324-4437-429a-b827-f8878f5424c5)

This fixes #14 
